### PR TITLE
Improving object group fqdn poller: 

### DIFF
--- a/src/dns-update/fqdn-poller
+++ b/src/dns-update/fqdn-poller
@@ -2,43 +2,63 @@
 import sys
 import time
 import subprocess
+import requests
+import json
 from dns import reversename, resolver
+from dns.resolver import Resolver
 from dns.resolver import NXDOMAIN
 from dns.resolver import NoAnswer
 from dns.resolver import NoNameservers
 from dns.exception import Timeout
 from cli import cli
 from cli import configure
-
+from multiprocessing.dummy import Pool as ThreadPool
 
 '''
 This code is executed as a one-shot script and takes no parameters.
-It fetches all object-groups starting with FQDN-* and sync them up
-with the corresponding IPs, re-scheduling next shot the min(TTL)
+It fetches all object-groups containing the description field
+starting with FQDN:<fully.qualified.domain.name> and resolves to the
+corresponding IPs, re-scheduling the next iteration at the min(TTL)
 
-IOS-XE does not allow creation of empty object-groups, so addition
-of new FQDN based objects can be done as the following:
+Note: IOS-XE does not allow creation of empty object-groups, so adding
+new FQDN based objects must be done as the following:
 
-  object-group network FQDN-<host.domain.com>
+  object-group network ACME-WWW
     host 127.0.0.1
+    description FQDN:www.acme.com
 
-After the first iteration 127.0.0.1 will be replaced by the resolved IP(s)
+After first iteration 127.0.0.1 will be replaced by the resolved IP(s)
 '''
 
-DEBUG = False
+DEBUG_LOG   = False
+MAX_THREADS = 8
+MIN_TTL     = 30
 
 
 def log(message, severity):
     cli('send log %d "%s"' % (severity, message))
 
 
-def dns_lookup(name):
-    if DEBUG:
-        log("Looking up %s" % name, 5)
+def dns_lookup_Parallel(object_groups, threads=MAX_THREADS):
+    pool = ThreadPool(threads)
+    results = pool.map(dns_lookup, object_groups)
+    pool.close()
+    pool.join()
+    return results
+
+
+def dns_lookup(object_group):
+    global DEBUG_LOG
+    fqdn = objects[object_group]["fqdn"]
+    if DEBUG_LOG:
+        log("Looking up %s" % fqdn, 5)
 
     try:
-        answers = resolver.query(name, 'A')
-        return answers.rrset.ttl, [answer.address for answer in answers]
+        answers = resolver.query(fqdn, 'A')
+        objects[object_group]["resolved"]   = [answer.address for answer in answers]
+        objects[object_group]["ttl"]        = find_ttl(fqdn)
+
+        pass
 
     except NXDOMAIN:
         pass
@@ -49,73 +69,177 @@ def dns_lookup(name):
     except Timeout:
         pass
 
+def find_ttl(zone):
+    resolver = Resolver()
+    tokens = zone.split(".")
 
-def object_group_lookup(fqdn):
-    ips = cli("show object-group name FQDN-%s | i host" % (fqdn)).split('\n')
-    return [x.split("host ")[1] for x in ips if x]
+    # Find Authoritative DNS Servers
+    while True:
+        if not tokens:
+            break
+
+        try:
+            answers         = resolver.query(".".join(tokens), 'NS')
+            authoritatives  = [resolver.query(str(answer))[0].address for answer in answers]
+            if authoritatives:
+                break
+
+        except NXDOMAIN:
+            pass
+        except NoAnswer:
+            pass
+        except NoNameservers:
+            pass
+        except Timeout:
+            pass
+
+        tokens.pop(0)
 
 
-def object_group_configure(fqdn,ip,template,action):
+    # Query TTL against authoritatives
+    resolver.nameservers = authoritatives
+    try:
+        ttl = resolver.query(zone, 'A').rrset.ttl
+        # Return zone TTL
+        return ttl
+
+    except NXDOMAIN:
+        pass
+    except NoAnswer:
+        pass
+    except NoNameservers:
+        pass
+    except Timeout:
+        pass
+
+    # Return default TTL in case not found
+    return MIN_TTL
+
+
+def restconf(method,resource):
+    # can't use because REST API returns a single element instead of list of all elements
+    # in a future when Cisco fixes it'll be preferred over the current object_group_lookup() parser
+
+    self_ip = cli("show ip interface GigabitEthernet 0").split("\n")[2].split(" ")[-1].split("/")[0]
+    rest_url = "https://%s/restconf/data/Cisco-IOS-XE-native:native/Cisco-IOS-XE-native:" % (SELF_IP)
+    headers = {
+        'accept': "application/yang-data+json"
+    }
+    query = {"with-defaults":"report-all"}
+    query = {"depth":"4"}
+    response = requests.request(method, rest_url + resource, params=query, headers=headers, verify=False, auth=('admin', 'ldaldalda111'))
+    return json.loads(response.text)
+
+
+def object_group_lookup():
+    text = cli("show object-group").splitlines()
+    object_groups = {}
+
+    for i in range(len(text)):
+        line = text[i]
+        if "Description FQDN:" in line:
+            fqdn = line.split("Description FQDN:")[1]
+            name = text[i-1].split("Network object group ")[1]
+
+            object_groups[name] = {
+                "fqdn": fqdn,
+                "hosts": []
+            }
+
+            try:
+                for x in xrange(16):
+                        cur_line = text[i+x+1]
+
+                        if "host" in cur_line:
+                            object_groups[name]["hosts"].append(cur_line.split("host ")[1])
+
+                        if "Network" in cur_line:
+                            break
+
+                        if "object" in cur_line:
+                            break
+
+                        if cur_line == "":
+                            break
+
+            except:
+                continue
+
+    return object_groups
+
+
+def object_group_configure(object_group,ip,action):
+    OBJECT_GROUP_ADD = """
+object-group network %s
+  host %s
+"""
+
+    OBJECT_GROUP_DEL = """
+object-group network %s
+  no host %s
+"""
     localtime = time.asctime(time.localtime(time.time()))
     remark = "Added %s @%s" % (ip,localtime)
-    responses = configure(template % (fqdn,ip))
+
+    if action == 'add':
+        responses = configure(OBJECT_GROUP_ADD % (object_group,ip))
+
+    if action == 'del':
+        responses = configure(OBJECT_GROUP_DEL % (object_group,ip))
+
     success = reduce (lambda x, y : x and y, [r.success for r in responses])
     status = "Success" if success else "Fail"
-    log("RESOLVER(%s): %s IP: %s - status: %s" % (fqdn, action, ip, status), 5)
+    log("RESOLVER(%s): %s IP: %s - status: %s" % (object_group, action, ip, status), 5)
+
 
 def reschedule(seconds):
-
+    global DEBUG_LOG
     UPDATE_SCRIPT_FIRING_COMMANDS = """
 event manager applet FQDN-POLLER
  event timer watchdog time %s
  action 1.0 cli command "enable"
  action 1.1 cli command "guestshell run /home/guestshell/fqdn-poller
 """
-
     responses = configure(UPDATE_SCRIPT_FIRING_COMMANDS % (seconds))
     success = reduce(lambda x, y: x and y, [r.success for r in responses])
     status = "Success" if success else "Fail"
-    if DEBUG:
+    if DEBUG_LOG:
         log("reschedule in : %s seconds: status: %s" % (str(seconds), status), 5)
 
 
-def main(argv):
-    MIN_TTL = 30
 
-    OBJECT_GROUP_ADD = """object-group network FQDN-%s\n host %s\n"""
-    OBJECT_GROUP_DEL = """object-group network FQDN-%s\n no host %s\n"""
-
+def main():
+    global MIN_TTL
     # Fix guestshell resolvers
     p = subprocess.Popen("printf \"nameserver 10.100.0.9\nnameserver 10.104.0.9\n\" | sudo tee /etc/resolv.conf", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
+    # Fetch and resolve FQDN object groups
+    global objects
+    objects = object_group_lookup()
 
-    # Fetch current FQDN object groups
-    object_groups = cli("show object-group | i FQDN-").split('\n')
-    fqdns = [x.split("FQDN-")[1] for x in object_groups if x]
+    dns_lookup_Parallel(list(objects))
 
-    for fqdn in fqdns:
-        # DNS Lookup
-        ttl, resolved_ips = dns_lookup(fqdn)
+    for item in objects:
 
-        # Polling interval should consider the minimum original TTL
-        if ttl < MIN_TTL:
-            MIN_TTL = ttl + 1
+        # Diff resolved hosts vs. current object-group hosts
+        include           = list(set(objects[item]["resolved"]) - set(objects[item]["hosts"]))
+        exclude           = list(set(objects[item]["hosts"]) - set(objects[item]["resolved"]))
 
-        # Compare resolved IPs vs. object group IPs
-        object_group_ips  = object_group_lookup(fqdn)
-        include           = list(set(resolved_ips) - set(object_group_ips))
-        exclude           = list(set(object_group_ips) - set(resolved_ips))
-
-        # Synchronize config based on DNS Lookup IPs
+        # Synchronize config
         for ip in include:
-            object_group_configure(fqdn,ip,OBJECT_GROUP_ADD,"adding")
+            object_group_configure(item,ip,"add")
 
         for ip in exclude:
-            object_group_configure(fqdn,ip,OBJECT_GROUP_DEL,"removing")
+            object_group_configure(item,ip,"del")
 
-    # Sleep for minimum record TTL -- NEED FIX: answers.rrset.ttl = time for resolver cache to expire, not original TTL
+        # Polling interval should consider the minimum original TTL
+        ttl = objects[item]["ttl"]
+
+        if ttl < MIN_TTL >= 5:
+            MIN_TTL = ttl + 1
+
     reschedule(MIN_TTL)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/src/dns-update/fqdn-poller
+++ b/src/dns-update/fqdn-poller
@@ -30,16 +30,21 @@ new FQDN based objects must be done as the following:
 After first iteration 127.0.0.1 will be replaced by the resolved IP(s)
 '''
 
-DEBUG_LOG   = False
-MAX_THREADS = 8
-MIN_TTL     = 30
+class config():
+    DEBUG_LOG   = False
+    MAX_THREADS = 8
+    MIN_TTL     = 30
+    RESOLVERS = [
+        "8.8.8.8",
+        "8.8.4.4"
+]
 
 
 def log(message, severity):
     cli('send log %d "%s"' % (severity, message))
 
 
-def dns_lookup_Parallel(object_groups, threads=MAX_THREADS):
+def dns_lookup_Parallel(object_groups, threads=config.MAX_THREADS):
     pool = ThreadPool(threads)
     results = pool.map(dns_lookup, object_groups)
     pool.close()
@@ -48,9 +53,8 @@ def dns_lookup_Parallel(object_groups, threads=MAX_THREADS):
 
 
 def dns_lookup(object_group):
-    global DEBUG_LOG
     fqdn = objects[object_group]["fqdn"]
-    if DEBUG_LOG:
+    if config.DEBUG_LOG:
         log("Looking up %s" % fqdn, 5)
 
     try:
@@ -113,7 +117,7 @@ def find_ttl(zone):
         pass
 
     # Return default TTL in case not found
-    return MIN_TTL
+    return config.MIN_TTL
 
 
 def restconf(method,resource):
@@ -193,7 +197,6 @@ object-group network %s
 
 
 def reschedule(seconds):
-    global DEBUG_LOG
     UPDATE_SCRIPT_FIRING_COMMANDS = """
 event manager applet FQDN-POLLER
  event timer watchdog time %s
@@ -203,15 +206,14 @@ event manager applet FQDN-POLLER
     responses = configure(UPDATE_SCRIPT_FIRING_COMMANDS % (seconds))
     success = reduce(lambda x, y: x and y, [r.success for r in responses])
     status = "Success" if success else "Fail"
-    if DEBUG_LOG:
+    if config.DEBUG_LOG:
         log("reschedule in : %s seconds: status: %s" % (str(seconds), status), 5)
 
 
 
 def main():
-    global MIN_TTL
     # Fix guestshell resolvers
-    p = subprocess.Popen("printf \"nameserver 10.100.0.9\nnameserver 10.104.0.9\n\" | sudo tee /etc/resolv.conf", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    p = subprocess.Popen("printf \"nameserver %s\nnameserver %s\n\" | sudo tee /etc/resolv.conf" % (config.RESOLVERS[0],config.RESOLVERS[1]), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     # Fetch and resolve FQDN object groups
     global objects
@@ -235,10 +237,12 @@ def main():
         # Polling interval should consider the minimum original TTL
         ttl = objects[item]["ttl"]
 
-        if ttl < MIN_TTL >= 5:
-            MIN_TTL = ttl + 1
+        min_ttl = config.MIN_TTL
 
-    reschedule(MIN_TTL)
+        if ttl < min_ttl >= 5:
+            min_ttl = ttl + 1
+
+    reschedule(min_ttl)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- adding threadpool for parallel resolvers (starting with 8 = 1001HX cpu count)
- TTL bug fixed: now getting the TTL from authoritative servers
- moved FQDN logic to description field, allowing objects to be freely named and supporting FQDN longer than 64 chars.